### PR TITLE
exclude plasma-discover-packagekit from being installed

### DIFF
--- a/files/scripts/20-desktop.sh
+++ b/files/scripts/20-desktop.sh
@@ -10,6 +10,7 @@ if [[ "${VARIANT}" == "gnome" ]]; then
 
 elif [[ "${VARIANT}" == "kde" ]]; then
     dnf install -y \
+        --exclude=plasma-discover-packagekit \
         @"KDE Plasma Workspaces"
 
     systemctl enable sddm


### PR DESCRIPTION
This prevents `dnf` from installing `plasma-discover-packagekit`, which causes Discover to crash. Given that it's `rpm`/`yum`/`dnf` can't be used anyway, `plasma-discover-packagekit` is of no use their.