### PR TITLE
add cosmic desktop

### DIFF
--- a/.github/actions/config/action.yml
+++ b/.github/actions/config/action.yml
@@ -57,7 +57,7 @@ runs:
         IMAGE_PATH="almalinuxorg"
         IMAGE_NAME="atomic-desktop"
         PLATFORMS="arm64,amd64,amd64/v2"
-        VARIANTS="gnome,kde"
+        VARIANTS="gnome,kde,cosmic"
 
         echo "REGISTRY=${REGISTRY}" >> $GITHUB_OUTPUT
         echo "REGISTRY_USER=${REGISTRY_USER}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -11,6 +11,7 @@ on:
         options:
           - 'gnome'
           - 'kde'
+          - 'cosmic'
           - 'ALL'
 
 concurrency:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -107,7 +107,9 @@ jobs:
             - Systemd: <relver:systemd>
             - Glibc: <relver:glibc>
             - Bootc: <relver:bootc>
-            - ${{ inputs.variant == 'gnome' && 'GNOME: <version:gdm>' || 'KDE: <version:plasma-desktop>' }}
+            - ${{ inputs.variant == 'gnome' && 'GNOME: <version:gdm>'
+                || inputs.variant == 'kde' && 'KDE: <version:plasma-desktop>'
+                || inputs.variant == 'cosmic' && 'COSMIC: <version:cosmic-epoch>' }}
       KMS_KEY_ALIAS: ${{ inputs.KMS_KEY_ALIAS }}
       AWS_REGION: ${{ inputs.AWS_REGION }}
       generate-sbom: true

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ to get you started. Create your own Atomic AlmaLinux respin in minutes!
 Download and install from the ISOs:
 * [atomic-desktop-gnome-amd64.iso](https://almalinux-atomic.s3-accelerate.dualstack.amazonaws.com/atomic-desktop/latest/atomic-desktop-gnome-amd64.iso)
 * [atomic-desktop-kde-amd64.iso](https://almalinux-atomic.s3-accelerate.dualstack.amazonaws.com/atomic-desktop/latest/atomic-desktop-kde-amd64.iso)
+* [atomic-desktop-cosmic-amd64.iso](https://almalinux-atomic.s3-accelerate.dualstack.amazonaws.com/atomic-desktop/latest/atomic-desktop-cosmic-amd64.iso)
 
 Bootc images:
 * `quay.io/almalinuxorg/atomic-desktop-gnome`
 * `quay.io/almalinuxorg/atomic-desktop-kde`
+* `quay.io/almalinuxorg/atomic-desktop-cosmic`
 * Cosign public key: [cosign.pub](/cosign.pub)
 
 # Contributing

--- a/files/scripts/20-desktop.sh
+++ b/files/scripts/20-desktop.sh
@@ -31,6 +31,20 @@ elif [[ "${VARIANT}" == "kde" ]]; then
 
     systemctl enable sddm
 
+elif [[ "${VARIANT}" == "cosmic" ]]; then
+    # workaround: cosmic-greeter requires fprintd-pam but for aarch64 it's only in devel repo
+    if [[ "${TARGETARCH}" == "arm64" && ! $(dnf repoinfo devel -q | grep enabled) ]]; then
+        dnf install -y almalinux-release-devel
+        dnf config-manager --set-disabled devel
+        dnf install -y fprintd-pam --enablerepo=devel
+    fi
+
+    dnf copr enable -y "ligenix/enterprise-cosmic" "rhel+epel-10-$(uname -m)"
+    dnf install -y \
+        cosmic-desktop
+
+    systemctl enable cosmic-greeter
+
 else
     true
 

--- a/files/scripts/20-desktop.sh
+++ b/files/scripts/20-desktop.sh
@@ -2,20 +2,23 @@
 
 set -xeuo pipefail
 
+dnf install -y \
+    @core \
+    @fonts \
+    @guest-desktop-agents \
+    @hardware-support \
+    @input-methods \
+    @multimedia \
+    @networkmanager-submodules \
+    @print-client \
+    @standard
+
 if [[ "${VARIANT}" == "gnome" ]]; then
     # aarch64 doesn't have @workstation group
     if [[ "${TARGETARCH}" == "arm64" ]]; then
         dnf install -y \
-            @core \
-            @fonts \
             @gnome-desktop \
-            @guest-desktop-agents \
-            @hardware-support \
             @internet-browser \
-            @multimedia \
-            @networkmanager-submodules \
-            @print-client \
-            @standard \
             @workstation-product
     else
         dnf install -y \


### PR DESCRIPTION
aarch64 workaround included
to be cleaned up if cosmic-greeter drops fprintd-pam dependency or fprintd-pam becomes available in appstream in aarch64

test build: https://github.com/eseiker/atomic-desktop/actions/runs/23330655032